### PR TITLE
Fix splat wildcard rule

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -70,8 +70,8 @@ function isNetlifyRule(
 function handleWildcardRules(rule: ParsedNetlifyRule): ParsedNetlifyRule {
   return {
     ...rule,
-    source: rule.source.replace(/\/\*$/, "/:splat*"),
-    destination: rule.destination.replace(/\/:splat$/, "/:splat*"),
+    source: rule.source.replace(/\/\*$/, "/:splat+"),
+    destination: rule.destination.replace(/\/:splat$/, "/:splat+"),
   };
 }
 


### PR DESCRIPTION
- 🎟️ [Asana](https://app.asana.com/0/346384260719996/1192968935726065)

The current translation _may_ be causing an endless redirect.